### PR TITLE
Handle sell transactions in profit analytics

### DIFF
--- a/app/services/profit_analytics_service.rb
+++ b/app/services/profit_analytics_service.rb
@@ -68,11 +68,16 @@ class ProfitAnalyticsService
   end
 
   def calculate_asset_invested(asset_transactions)
-    asset_transactions.sum { |t| t.quantity * t.nav }
+    asset_transactions.sum do |t|
+      amount = t.quantity * t.nav
+      t.transaction_type == 'sell' ? -amount : amount
+    end
   end
 
   def calculate_asset_quantity(asset_transactions)
-    asset_transactions.sum(&:quantity)
+    asset_transactions.sum do |t|
+      t.transaction_type == 'sell' ? -t.quantity : t.quantity
+    end
   end
 
   def calculate_asset_current_value(asset_transactions, asset)

--- a/spec/services/profit_analytics_service_spec.rb
+++ b/spec/services/profit_analytics_service_spec.rb
@@ -155,6 +155,37 @@ RSpec.describe ProfitAnalyticsService do
       end
     end
 
+    context 'with sell transactions' do
+      before do
+        create(:asset_price, asset: asset, price: 60.0, synced_at: Time.current)
+
+        create(:investment_transaction,
+               user: user,
+               asset: asset,
+               quantity: 100,
+               nav: 50.0,
+               transaction_type: 'buy')
+
+        create(:investment_transaction,
+               user: user,
+               asset: asset,
+               quantity: 40,
+               nav: 70.0,
+               transaction_type: 'sell')
+      end
+
+      it 'deducts sold quantity and updates profit' do
+        result = service.calculate_profit
+        asset_data = result[:category_details]['Stocks'][:assets].first
+
+        expect(asset_data[:quantity]).to eq(60.0)
+        expect(asset_data[:invested]).to eq(2200.0)
+        expect(asset_data[:current_value]).to eq(3600.0)
+        expect(asset_data[:profit]).to eq(1400.0)
+        expect(asset_data[:profit_percentage]).to eq(63.64)
+      end
+    end
+
     context 'with loss scenario' do
       before do
         # Create asset price (lower than purchase price)


### PR DESCRIPTION
## Summary
- adjust profit analytics to treat sell transactions as negative quantity and cash flow
- test profit analytics service with both buy and sell transactions

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689770848d888326bfcc29976002b6d2