### PR TITLE
Align test JWT secret usage with application controllers

### DIFF
--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -9,7 +9,7 @@ module AuthHelpers
         exp: 24.hours.from_now.to_i,
         user_id: user.id, # Add this explicitly for compatibility
       },
-      Rails.application.credentials.secret_key_base
+      Rails.application.credentials.jwt_secret_key || Rails.application.secret_key_base
     )
     { 'Authorization' => "Bearer #{token}" }
   end


### PR DESCRIPTION
## Summary
- use `Rails.application.credentials.jwt_secret_key || Rails.application.secret_key_base` when generating test auth headers

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b4231d7c58832684b8d8831d63b642